### PR TITLE
Remove redundant spaces

### DIFF
--- a/manuals/vm/seedvm-from-scratch.md
+++ b/manuals/vm/seedvm-from-scratch.md
@@ -146,7 +146,7 @@ After rebooting the machine, the copy-and-paste will work.
 
 Most of the software package installation steps are automated with shell
 scripts. We will install many software packages, and we group them
-into individual shell scripts and they are stored in the  
+into individual shell scripts and they are stored in the 
 [`lab-setup/ubuntu20.04-vm/src-vm`](https://github.com/seed-labs/seed-labs/tree/master/lab-setup/ubuntu20.04-vm/src-vm) 
 folders of the SEED Labs GitHub repo. The main script is called `main.sh`, 
 which will invoke all the other shell scripts in this folder. 


### PR DESCRIPTION
Two spaces means a newline in the markdown syntax. Remove redundant spaces to make markdown document looks good.